### PR TITLE
Get sync-sat working with prep-shim

### DIFF
--- a/server/bin/gold/test-0.1.txt
+++ b/server/bin/gold/test-0.1.txt
@@ -1,9 +1,9 @@
-+++ Running pbench-server-prep-shim-002
-pbench-server-prep-shim-002: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
---- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-sync-satellite satellite-one
 pbench-sync-satellite: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-sync-satellite (status=1)
++++ Running pbench-server-prep-shim-002
+pbench-server-prep-shim-002: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
+--- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-dispatch
 pbench-dispatch: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-dispatch (status=1)

--- a/server/bin/gold/test-0.2.txt
+++ b/server/bin/gold/test-0.2.txt
@@ -1,9 +1,9 @@
-+++ Running pbench-server-prep-shim-002
-pbench-server-prep-shim-002: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
---- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-sync-satellite satellite-one
 pbench-sync-satellite: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-sync-satellite (status=1)
++++ Running pbench-server-prep-shim-002
+pbench-server-prep-shim-002: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
+--- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-dispatch
 pbench-dispatch: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-dispatch (status=1)

--- a/server/bin/gold/test-0.txt
+++ b/server/bin/gold/test-0.txt
@@ -1,9 +1,9 @@
-+++ Running pbench-server-prep-shim-002
-pbench-server-prep-shim-002: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
---- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-sync-satellite satellite-one
 pbench-sync-satellite: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-sync-satellite (status=1)
++++ Running pbench-server-prep-shim-002
+pbench-server-prep-shim-002: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
+--- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-dispatch
 pbench-dispatch: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-dispatch (status=1)

--- a/server/bin/gold/test-1.txt
+++ b/server/bin/gold/test-1.txt
@@ -1,9 +1,9 @@
-+++ Running pbench-server-prep-shim-002
-pbench-server-prep-shim-002: Bad ARCHIVE=/var/tmp/pbench-test-server/test-1/pbench/archive/fs-version-001
---- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-sync-satellite satellite-one
 pbench-sync-satellite: Bad ARCHIVE=/var/tmp/pbench-test-server/test-1/pbench/archive/fs-version-001
 --- Finished pbench-sync-satellite (status=1)
++++ Running pbench-server-prep-shim-002
+pbench-server-prep-shim-002: Bad ARCHIVE=/var/tmp/pbench-test-server/test-1/pbench/archive/fs-version-001
+--- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-dispatch
 pbench-dispatch: Bad ARCHIVE=/var/tmp/pbench-test-server/test-1/pbench/archive/fs-version-001
 --- Finished pbench-dispatch (status=1)

--- a/server/bin/gold/test-10.txt
+++ b/server/bin/gold/test-10.txt
@@ -20,9 +20,9 @@ len(actions) = 1
             "chunk_id": 1,
             "doctype": "status",
             "name": "pbench-sync-satellite",
-            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files, with 0 md5 failures and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors\n",
+            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors\n",
             "total_chunks": 1,
-            "total_size": 570
+            "total_size": 528
         },
         "_type": "pbench-server-reports"
     }
@@ -132,7 +132,7 @@ drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--          0 logs/pbench-sync-satellite/ONE/change_state.log
 -rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
--rw-rw-r--        870 logs/pbench-sync-satellite/pbench-sync-satellite.log
+-rw-rw-r--        849 logs/pbench-sync-satellite/pbench-sync-satellite.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
 drwxrwxr-x          - quarantine
@@ -205,7 +205,7 @@ run-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01
 run-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: duration (secs): 0
-run-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors
+run-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log

--- a/server/bin/gold/test-11.txt
+++ b/server/bin/gold/test-11.txt
@@ -20,9 +20,9 @@ len(actions) = 1
             "chunk_id": 1,
             "doctype": "status",
             "name": "pbench-sync-satellite",
-            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 2 files, with 1 md5 failures and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\npbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED\npbench-sync-satellite: completing satellite state changes ... (/var/tmp/pbench-test-server/test-11/pbench-local/logs/pbench-sync-satellite/ONE/change_state.log)\npbench-sync-satellite: completed satellite state changes\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 2 files processed, with 1 md5 failures and 0 errors\n",
+            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 1 errors\nRemote ONE: processed 1 files and 1 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\npbench-sync-satellite: completing satellite state changes ... (/var/tmp/pbench-test-server/test-11/pbench-local/logs/pbench-sync-satellite/ONE/change_state.log)\npbench-sync-satellite: completed satellite state changes\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 1 files processed and 1 errors\n",
             "total_chunks": 1,
-            "total_size": 848
+            "total_size": 746
         },
         "_type": "pbench-server-reports"
     }
@@ -89,37 +89,6 @@ lrwxrwxrwx         70 users -> /var/tmp/pbench-test-server/test-11/pbench-satell
 +++ pbench tree state (/var/tmp/pbench-test-server/test-11/pbench)
 drwxrwxr-x          - archive
 drwxrwxr-x          - archive/fs-version-001
-drwxrwxr-x          - archive/fs-version-001/ONE::controller
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/BACKED-UP
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/BACKUP-FAILED
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/BAD-MD5
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/COPIED-SOS
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/INDEXED
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/SATELLITE-DONE
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/SATELLITE-MD5-FAILED
-lrwxrwxrwx        133 archive/fs-version-001/ONE::controller/SATELLITE-MD5-FAILED/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz -> /var/tmp/pbench-test-server/test-11/pbench/archive/fs-version-001/ONE::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/SATELLITE-MD5-PASSED
-lrwxrwxrwx        113 archive/fs-version-001/ONE::controller/SATELLITE-MD5-PASSED/fio__2016-08-16_22:03:11.tar.xz -> /var/tmp/pbench-test-server/test-11/pbench/archive/fs-version-001/ONE::controller/fio__2016-08-16_22:03:11.tar.xz
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/SYNCED
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-BACKUP
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-COPY-SOS
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-DELETE
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-INDEX
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-INDEX-TOOL
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-LINK
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-RE-INDEX
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-RE-UNPACK
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-SYNC
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TO-UNPACK
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/TODO
-lrwxrwxrwx        113 archive/fs-version-001/ONE::controller/TODO/fio__2016-08-16_22:03:11.tar.xz -> /var/tmp/pbench-test-server/test-11/pbench/archive/fs-version-001/ONE::controller/fio__2016-08-16_22:03:11.tar.xz
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/UNPACKED
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/WONT-INDEX
-drwxrwxr-x          - archive/fs-version-001/ONE::controller/WONT-UNPACK
--rw-r--r--    1558168 archive/fs-version-001/ONE::controller/fio__2016-08-16_22:03:11.tar.xz
--rw-r--r--         66 archive/fs-version-001/ONE::controller/fio__2016-08-16_22:03:11.tar.xz.md5
--rw-r--r--       7028 archive/fs-version-001/ONE::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
--rw-r--r--         86 archive/fs-version-001/ONE::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/controller
 drwxrwxr-x          - archive/fs-version-001/controller/TODO
 lrwxrwxrwx         34 archive/fs-version-001/controller/TODO/fio__2016-08-16_22:03:11.tar.xz -> ../fio__2016-08-16_22:03:11.tar.xz
@@ -164,14 +133,13 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--        437 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
-drwxrwxr-x          - logs/pbench-sync-satellite/ONE/run-1970-01-01T00:00:42-UTC
-drwxrwxr-x          - logs/pbench-sync-satellite/ONE/run-1970-01-01T00:00:42-UTC/controller
--rw-rw-r--         60 logs/pbench-sync-satellite/ONE/run-1970-01-01T00:00:42-UTC/controller/fail-checks.log
--rw-rw-r--         96 logs/pbench-sync-satellite/ONE/run-1970-01-01T00:00:42-UTC/controller/md5-checks.log
--rw-rw-r--        218 logs/pbench-sync-satellite/pbench-sync-satellite.error
--rw-rw-r--       1013 logs/pbench-sync-satellite/pbench-sync-satellite.log
+-rw-rw-r--        508 logs/pbench-sync-satellite/pbench-sync-satellite.error
+-rw-rw-r--       1021 logs/pbench-sync-satellite/pbench-sync-satellite.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002/ONE::controller
+-rw-r--r--    1558168 pbench-move-results-receive/fs-version-002/ONE::controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 pbench-move-results-receive/fs-version-002/ONE::controller/fio__2016-08-16_22:03:11.tar.xz.md5
 drwxrwxr-x          - quarantine
 drwxrwxr-x          - quarantine/duplicates-002
 drwxrwxr-x          - quarantine/errors-002
@@ -234,14 +202,8 @@ drwxrwxr-x          - tmp
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-audit-server/pbench-audit-server.log
-+++++ pbench-sync-satellite/ONE/run-1970-01-01T00:00:42-UTC/controller/fail-checks.log
-pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
------ pbench-sync-satellite/ONE/run-1970-01-01T00:00:42-UTC/controller/fail-checks.log
-+++++ pbench-sync-satellite/ONE/run-1970-01-01T00:00:42-UTC/controller/md5-checks.log
-fio__2016-08-16_22:03:11.tar.xz: OK
-pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
------ pbench-sync-satellite/ONE/run-1970-01-01T00:00:42-UTC/controller/md5-checks.log
 +++++ pbench-sync-satellite/pbench-sync-satellite.error
+Failure moving tar ball /var/tmp/pbench-test-server/test-11/pbench-local/tmp/pbench-sync-satellite.XXXXX/unpack.ONE/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz to /var/tmp/pbench-test-server/test-11/pbench-local/pbench-move-results-receive/fs-version-002/ONE::controller
 pbench-sync-satellite: completing satellite state changes ... (/var/tmp/pbench-test-server/test-11/pbench-local/logs/pbench-sync-satellite/ONE/change_state.log)
 pbench-sync-satellite: completed satellite state changes
 ----- pbench-sync-satellite/pbench-sync-satellite.error
@@ -249,11 +211,10 @@ pbench-sync-satellite: completed satellite state changes
 run-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC
-fio__2016-08-16_22:03:11.tar.xz.md5 pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-md5sum: WARNING: 1 computed checksum did NOT match
+mv: failed on /var/tmp/pbench-test-server/test-11/pbench-local/tmp/pbench-sync-satellite.XXXXX/unpack.ONE/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz ./
 run-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: duration (secs): 0
-run-1970-01-01T00:00:42-UTC: Total 2 files processed, with 1 md5 failures and 0 errors
+run-1970-01-01T00:00:42-UTC: Total 1 files processed and 1 errors
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log

--- a/server/bin/gold/test-16.txt
+++ b/server/bin/gold/test-16.txt
@@ -50,14 +50,14 @@ len(actions) = 1
             "chunk_id": 1,
             "doctype": "status",
             "name": "pbench-audit-server",
-            "text": "pbench-audit-server.run-1970-01-01T00:00:42-UTC (unit-test) - Successful audit, nothing to report.\n",
+            "text": "pbench-audit-server.run-1970-01-01T00:00:42-UTC (unit-test)\n\n\n\nstart-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-16/pbench/public_html/results\n\nResults issues for controller: controller02\n\tTar ball links with unused prefix files:\n\t\tbenchmark-result-small_1970-01-01T00:00:00\n\nend-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-16/pbench/public_html/results\n",
             "total_chunks": 1,
-            "total_size": 99
+            "total_size": 420
         },
         "_type": "pbench-server-reports"
     }
 ]
---- Finished unit test audit (status=0)
+--- Finished unit test audit (status=1)
 +++ var/www/html tree state (/var/tmp/pbench-test-server/test-16/var-www-html)
 lrwxrwxrwx         63 incoming -> /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming
 drwxrwxr-x          - pbench-results-host-info.versioned
@@ -201,8 +201,7 @@ drwxrwxr-x          - public_html/results/controller01
 drwxrwxr-x          - public_html/results/controller01/prefix01
 lrwxrwxrwx        120 public_html/results/controller01/prefix01/benchmark-result-medium_1970-01-01T00:00:00 -> /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller01/benchmark-result-medium_1970-01-01T00:00:00
 drwxrwxr-x          - public_html/results/controller02
-drwxrwxr-x          - public_html/results/controller02/prefix02
-lrwxrwxrwx        119 public_html/results/controller02/prefix02/benchmark-result-small_1970-01-01T00:00:00 -> /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller02/benchmark-result-small_1970-01-01T00:00:00
+lrwxrwxrwx        119 public_html/results/controller02/benchmark-result-small_1970-01-01T00:00:00 -> /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller02/benchmark-result-small_1970-01-01T00:00:00
 drwxrwxr-x          - public_html/static
 drwxrwxr-x          - public_html/static/css
 drwxrwxr-x          - public_html/static/css/v0.2
@@ -231,10 +230,10 @@ lrwxrwxrwx        120 public_html/users/user01/controller01/prefix01/benchmark-r
 drwxrwxr-x          - logs
 drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
--rw-rw-r--        437 logs/pbench-audit-server/pbench-audit-server.log
+-rw-rw-r--        796 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-unpack-tarballs-small
 -rw-rw-r--        202 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
--rw-rw-r--       1970 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
+-rw-rw-r--       1961 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
 drwxrwxr-x          - quarantine
@@ -285,6 +284,15 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.error
 ----- pbench-audit-server/pbench-audit-server.error
 +++++ pbench-audit-server/pbench-audit-server.log
+
+
+start-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-16/pbench/public_html/results
+
+Results issues for controller: controller02
+	Tar ball links with unused prefix files:
+		benchmark-result-small_1970-01-01T00:00:00
+
+end-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-16/pbench/public_html/results
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-audit-server/pbench-audit-server.log
@@ -298,7 +306,7 @@ ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller
 run-1970-01-01T00:00:42-UTC: controller01/benchmark-result-medium_1970-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 3180
 ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller00/benchmark-result-large_1970-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/results/controller00/benchmark-result-large_1970-01-01T00:00:00
 run-1970-01-01T00:00:42-UTC: controller00/benchmark-result-large_1970-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 10240
-ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller02/benchmark-result-small_1970-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/results/controller02/prefix02/benchmark-result-small_1970-01-01T00:00:00
+ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller02/benchmark-result-small_1970-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/results/controller02/benchmark-result-small_1970-01-01T00:00:00
 run-1970-01-01T00:00:42-UTC: controller02/benchmark-result-small_1970-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 848
 run-1970-01-01T00:00:42-UTC: Processed 3 tarballs
 1970-01-01T00:00:42.000000 DEBUG pbench-unpack-tarballs-small.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)

--- a/server/bin/gold/test-17.txt
+++ b/server/bin/gold/test-17.txt
@@ -50,14 +50,14 @@ len(actions) = 1
             "chunk_id": 1,
             "doctype": "status",
             "name": "pbench-audit-server",
-            "text": "pbench-audit-server.run-1970-01-01T00:00:42-UTC (unit-test) - Successful audit, nothing to report.\n",
+            "text": "pbench-audit-server.run-1970-01-01T00:00:42-UTC (unit-test)\n\n\n\nstart-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-17/pbench/public_html/results\n\nResults issues for controller: controller02\n\tTar ball links with unused prefix files:\n\t\tbenchmark-result-small_1970-01-01T00:00:00\n\nend-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-17/pbench/public_html/results\n",
             "total_chunks": 1,
-            "total_size": 99
+            "total_size": 420
         },
         "_type": "pbench-server-reports"
     }
 ]
---- Finished unit test audit (status=0)
+--- Finished unit test audit (status=1)
 +++ var/www/html tree state (/var/tmp/pbench-test-server/test-17/var-www-html)
 lrwxrwxrwx         63 incoming -> /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming
 drwxrwxr-x          - pbench-results-host-info.versioned
@@ -201,8 +201,7 @@ drwxrwxr-x          - public_html/results/controller01
 drwxrwxr-x          - public_html/results/controller01/prefix01
 lrwxrwxrwx        120 public_html/results/controller01/prefix01/benchmark-result-medium_1970-01-01T00:00:00 -> /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller01/benchmark-result-medium_1970-01-01T00:00:00
 drwxrwxr-x          - public_html/results/controller02
-drwxrwxr-x          - public_html/results/controller02/prefix02
-lrwxrwxrwx        119 public_html/results/controller02/prefix02/benchmark-result-small_1970-01-01T00:00:00 -> /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller02/benchmark-result-small_1970-01-01T00:00:00
+lrwxrwxrwx        119 public_html/results/controller02/benchmark-result-small_1970-01-01T00:00:00 -> /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller02/benchmark-result-small_1970-01-01T00:00:00
 drwxrwxr-x          - public_html/static
 drwxrwxr-x          - public_html/static/css
 drwxrwxr-x          - public_html/static/css/v0.2
@@ -231,10 +230,10 @@ lrwxrwxrwx        120 public_html/users/user01/controller01/prefix01/benchmark-r
 drwxrwxr-x          - logs
 drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
--rw-rw-r--        437 logs/pbench-audit-server/pbench-audit-server.log
+-rw-rw-r--        796 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-unpack-tarballs-small
 -rw-rw-r--        202 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
--rw-rw-r--       1969 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
+-rw-rw-r--       1960 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
 drwxrwxr-x          - quarantine
@@ -285,6 +284,15 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.error
 ----- pbench-audit-server/pbench-audit-server.error
 +++++ pbench-audit-server/pbench-audit-server.log
+
+
+start-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-17/pbench/public_html/results
+
+Results issues for controller: controller02
+	Tar ball links with unused prefix files:
+		benchmark-result-small_1970-01-01T00:00:00
+
+end-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-17/pbench/public_html/results
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-audit-server/pbench-audit-server.log
@@ -298,7 +306,7 @@ ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller
 run-1970-01-01T00:00:42-UTC: controller01/benchmark-result-medium_1970-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 3176
 ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller00/benchmark-result-large_1970-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/results/controller00/benchmark-result-large_1970-01-01T00:00:00
 run-1970-01-01T00:00:42-UTC: controller00/benchmark-result-large_1970-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 5920
-ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller02/benchmark-result-small_1970-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/results/controller02/prefix02/benchmark-result-small_1970-01-01T00:00:00
+ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller02/benchmark-result-small_1970-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/results/controller02/benchmark-result-small_1970-01-01T00:00:00
 run-1970-01-01T00:00:42-UTC: controller02/benchmark-result-small_1970-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 848
 run-1970-01-01T00:00:42-UTC: Processed 3 tarballs
 1970-01-01T00:00:42.000000 DEBUG pbench-unpack-tarballs-small.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)

--- a/server/bin/gold/test-2.txt
+++ b/server/bin/gold/test-2.txt
@@ -1,3 +1,33 @@
++++ Running pbench-sync-satellite satellite-one
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:42",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-sync-satellite",
+            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors\n",
+            "total_chunks": 1,
+            "total_size": 528
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-server-prep-shim-002
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -28,36 +58,6 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-server-prep-shim-002 (status=0)
-+++ Running pbench-sync-satellite satellite-one
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-01 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-01",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-01-01T00:00:42",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-sync-satellite",
-            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files, with 0 md5 failures and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors\n",
-            "total_chunks": 1,
-            "total_size": 570
-        },
-        "_type": "pbench-server-reports"
-    }
-]
---- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-dispatch
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -259,7 +259,7 @@ drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--          0 logs/pbench-sync-satellite/ONE/change_state.log
 -rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
--rw-rw-r--        870 logs/pbench-sync-satellite/pbench-sync-satellite.log
+-rw-rw-r--        849 logs/pbench-sync-satellite/pbench-sync-satellite.log
 drwxrwxr-x          - logs/pbench-verify-backup-tarballs
 -rw-rw-r--       3060 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -359,7 +359,7 @@ run-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01
 run-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: duration (secs): 0
-run-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors
+run-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log

--- a/server/bin/gold/test-22.txt
+++ b/server/bin/gold/test-22.txt
@@ -20,9 +20,9 @@ len(actions) = 1
             "chunk_id": 1,
             "doctype": "status",
             "name": "pbench-satellite-cleanup",
-            "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 6 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.\n\n",
+            "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 6 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.\n\n",
             "total_chunks": 1,
-            "total_size": 274
+            "total_size": 257
         },
         "_type": "pbench-server-reports"
     }
@@ -50,9 +50,9 @@ len(actions) = 1
             "chunk_id": 1,
             "doctype": "status",
             "name": "pbench-audit-server",
-            "text": "pbench-audit-server.run-1970-01-01T00:00:42-UTC (unit-test)\n\n\nstart-1970-01-01T00:00:42-UTC: archive hierarchy: /var/tmp/pbench-test-server/test-22/pbench/archive/fs-version-001\n\nController: controller-a\n\t* No tar ball files found in this controller directory.\n\nController: controller-b\n\t* No tar ball files found in this controller directory.\n\nController: controller-c\n\t* No tar ball files found in this controller directory.\n\nend-1970-01-01T00:00:42-UTC: archive hierarchy: /var/tmp/pbench-test-server/test-22/pbench/archive/fs-version-001\n\n\nstart-1970-01-01T00:00:42-UTC: incoming hierarchy: /var/tmp/pbench-test-server/test-22/pbench/public_html/incoming\n\nControllers which are empty:\n\tcontroller-a\n\tcontroller-c\n\nend-1970-01-01T00:00:42-UTC: incoming hierarchy: /var/tmp/pbench-test-server/test-22/pbench/public_html/incoming\n\n\nstart-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-22/pbench/public_html/results\n\nControllers which are empty:\n\tcontroller-a\n\nResults issues for controller: controller-c\n\tEmpty tar ball directories:\n\t\tdirA/dirB\n\nend-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-22/pbench/public_html/results\n",
+            "text": "pbench-audit-server.run-1970-01-01T00:00:42-UTC (unit-test)\n\n\nstart-1970-01-01T00:00:42-UTC: archive hierarchy: /var/tmp/pbench-test-server/test-22/pbench/archive/fs-version-001\n\nController: controller-a\n\t* No tar ball files found in this controller directory.\n\nController: controller-b\n\t* No tar ball files found in this controller directory.\n\nController: controller-c\n\t* No tar ball files found in this controller directory.\n\nend-1970-01-01T00:00:42-UTC: archive hierarchy: /var/tmp/pbench-test-server/test-22/pbench/archive/fs-version-001\n\n\nstart-1970-01-01T00:00:42-UTC: incoming hierarchy: /var/tmp/pbench-test-server/test-22/pbench/public_html/incoming\n\nControllers which are empty:\n\tcontroller-a\n\tcontroller-c\n\nend-1970-01-01T00:00:42-UTC: incoming hierarchy: /var/tmp/pbench-test-server/test-22/pbench/public_html/incoming\n\n\nstart-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-22/pbench/public_html/results\n\nControllers which are empty:\n\tcontroller-a\n\nResults issues for controller: controller-c\n\tInvalid tar ball links (not in /var/tmp/pbench-test-server/test-22/pbench/archive/fs-version-001):\n\t\tdirA/dirB/tarball-fiv_1970.01.01T00.00.00\n\nend-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-22/pbench/public_html/results\n",
             "total_chunks": 1,
-            "total_size": 1188
+            "total_size": 1291
         },
         "_type": "pbench-server-reports"
     }
@@ -101,6 +101,7 @@ lrwxrwxrwx         41 archive/fs-version-001/controller-b/SATELLITE-DONE/tarball
 drwxrwxr-x          - archive/fs-version-001/controller-b/TO-DELETE
 drwxrwxr-x          - archive/fs-version-001/controller-c
 drwxrwxr-x          - archive/fs-version-001/controller-c/.prefix
+-rw-rw-r--         10 archive/fs-version-001/controller-c/.prefix/tarball-fiv_1970.01.01T00.00.00.prefix
 drwxrwxr-x          - archive/fs-version-001/controller-c/SATELLITE-DONE
 lrwxrwxrwx         41 archive/fs-version-001/controller-c/SATELLITE-DONE/tarball-fiv_1970.01.01T00.00.00.tar.xz -> ../tarball-fiv_1970.01.01T00.00.00.tar.xz
 lrwxrwxrwx         41 archive/fs-version-001/controller-c/SATELLITE-DONE/tarball-six_1970.01.01T00.00.00.tar.xz -> ../tarball-six_1970.01.01T00.00.00.tar.xz
@@ -114,6 +115,7 @@ drwxrwxr-x          - public_html/results/controller-a
 drwxrwxr-x          - public_html/results/controller-c
 drwxrwxr-x          - public_html/results/controller-c/dirA
 drwxrwxr-x          - public_html/results/controller-c/dirA/dirB
+lrwxrwxrwx         65 public_html/results/controller-c/dirA/dirB/tarball-fiv_1970.01.01T00.00.00 -> ../../../../incoming/controller-c/tarball-fiv_1970.01.01T00.00.00
 drwxrwxr-x          - public_html/static
 drwxrwxr-x          - public_html/static/css
 drwxrwxr-x          - public_html/static/css/v0.2
@@ -138,10 +140,10 @@ drwxrwxr-x          - public_html/users
 drwxrwxr-x          - logs
 drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
--rw-rw-r--       1564 logs/pbench-audit-server/pbench-audit-server.log
+-rw-rw-r--       1667 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-satellite-cleanup
 -rw-rw-r--          0 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.error
--rw-rw-r--        759 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
+-rw-rw-r--        742 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
 drwxrwxr-x          - quarantine
@@ -221,8 +223,8 @@ Controllers which are empty:
 	controller-a
 
 Results issues for controller: controller-c
-	Empty tar ball directories:
-		dirA/dirB
+	Invalid tar ball links (not in /var/tmp/pbench-test-server/test-22/pbench/archive/fs-version-001):
+		dirA/dirB/tarball-fiv_1970.01.01T00.00.00
 
 end-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test-22/pbench/public_html/results
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
@@ -232,7 +234,7 @@ end-1970-01-01T00:00:42-UTC: results hierarchy: /var/tmp/pbench-test-server/test
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.error
 +++++ pbench-satellite-cleanup/pbench-satellite-cleanup.log
 run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup starting
-run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 6 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.
+run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 6 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.
 1970-01-01T00:00:42.000000 DEBUG pbench-satellite-cleanup.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-satellite-cleanup.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.log

--- a/server/bin/gold/test-3.txt
+++ b/server/bin/gold/test-3.txt
@@ -1,3 +1,33 @@
++++ Running pbench-sync-satellite satellite-one
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:42",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-sync-satellite",
+            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors\n",
+            "total_chunks": 1,
+            "total_size": 528
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-server-prep-shim-002
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -28,36 +58,6 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-server-prep-shim-002 (status=0)
-+++ Running pbench-sync-satellite satellite-one
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-01 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-01",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-01-01T00:00:42",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-sync-satellite",
-            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files, with 0 md5 failures and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors\n",
-            "total_chunks": 1,
-            "total_size": 570
-        },
-        "_type": "pbench-server-reports"
-    }
-]
---- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-dispatch
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -287,7 +287,7 @@ drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--          0 logs/pbench-sync-satellite/ONE/change_state.log
 -rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
--rw-rw-r--        870 logs/pbench-sync-satellite/pbench-sync-satellite.log
+-rw-rw-r--        849 logs/pbench-sync-satellite/pbench-sync-satellite.log
 drwxrwxr-x          - logs/pbench-verify-backup-tarballs
 -rw-rw-r--       3060 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -393,7 +393,7 @@ run-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01
 run-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: duration (secs): 0
-run-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors
+run-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log

--- a/server/bin/gold/test-4.txt
+++ b/server/bin/gold/test-4.txt
@@ -1,3 +1,33 @@
++++ Running pbench-sync-satellite satellite-one
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:42",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-sync-satellite",
+            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors\n",
+            "total_chunks": 1,
+            "total_size": 528
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-server-prep-shim-002
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -28,36 +58,6 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-server-prep-shim-002 (status=0)
-+++ Running pbench-sync-satellite satellite-one
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-01 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-01",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-01-01T00:00:42",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-sync-satellite",
-            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files, with 0 md5 failures and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors\n",
-            "total_chunks": 1,
-            "total_size": 570
-        },
-        "_type": "pbench-server-reports"
-    }
-]
---- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-dispatch
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -288,7 +288,7 @@ drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--          0 logs/pbench-sync-satellite/ONE/change_state.log
 -rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
--rw-rw-r--        870 logs/pbench-sync-satellite/pbench-sync-satellite.log
+-rw-rw-r--        849 logs/pbench-sync-satellite/pbench-sync-satellite.log
 drwxrwxr-x          - logs/pbench-verify-backup-tarballs
 -rw-rw-r--       3060 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -331,7 +331,7 @@ drwxrwxr-x          - public_html/static/js/v0.3/js
 drwxrwxr-x          - logs
 drwxrwxr-x          - logs/pbench-satellite-cleanup
 -rw-rw-r--          0 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.error
--rw-rw-r--        962 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
+-rw-rw-r--        928 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
 drwxrwxr-x          - logs/pbench-sync-package-tarballs
 -rw-rw-r--          0 logs/pbench-sync-package-tarballs/pbench-sync-package-tarballs.error
 -rw-rw-r--          0 logs/pbench-sync-package-tarballs/pbench-sync-package-tarballs.log
@@ -401,7 +401,7 @@ run-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01
 run-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: duration (secs): 0
-run-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors
+run-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log
@@ -434,8 +434,8 @@ run-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.error
 +++++ pbench-satellite-cleanup/pbench-satellite-cleanup.log
 run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup starting
-run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.
-1970-01-01T00:00:42.000000 INFO pbench-satellite-cleanup.report post_status -- @cee:{"@generated-by": {"commit_id": "unit-test", "group_id": 43, "hostname": "example.com", "pid": 42, "user_id": 44, "version": ""}, "@timestamp": "1970-01-01T00:00:42", "chunk_id": 1, "doctype": "status", "name": "pbench-satellite-cleanup", "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.\n\n", "total_chunks": 1, "total_size": 274}
+run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.
+1970-01-01T00:00:42.000000 INFO pbench-satellite-cleanup.report post_status -- @cee:{"@generated-by": {"commit_id": "unit-test", "group_id": 43, "hostname": "example.com", "pid": 42, "user_id": 44, "version": ""}, "@timestamp": "1970-01-01T00:00:42", "chunk_id": 1, "doctype": "status", "name": "pbench-satellite-cleanup", "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.\n\n", "total_chunks": 1, "total_size": 257}
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.log
 +++++ pbench-sync-package-tarballs/pbench-sync-package-tarballs.error
 ----- pbench-sync-package-tarballs/pbench-sync-package-tarballs.error

--- a/server/bin/gold/test-5.1.txt
+++ b/server/bin/gold/test-5.1.txt
@@ -1,3 +1,33 @@
++++ Running pbench-sync-satellite satellite-one
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:42",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-sync-satellite",
+            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors\n",
+            "total_chunks": 1,
+            "total_size": 528
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-server-prep-shim-002
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -28,36 +58,6 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-server-prep-shim-002 (status=0)
-+++ Running pbench-sync-satellite satellite-one
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-01 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-01",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-01-01T00:00:42",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-sync-satellite",
-            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files, with 0 md5 failures and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors\n",
-            "total_chunks": 1,
-            "total_size": 570
-        },
-        "_type": "pbench-server-reports"
-    }
-]
---- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-dispatch
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -403,7 +403,7 @@ drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--          0 logs/pbench-sync-satellite/ONE/change_state.log
 -rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
--rw-rw-r--        870 logs/pbench-sync-satellite/pbench-sync-satellite.log
+-rw-rw-r--        849 logs/pbench-sync-satellite/pbench-sync-satellite.log
 drwxrwxr-x          - logs/pbench-unpack-tarballs-small
 -rw-rw-r--          0 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
 -rw-rw-r--        533 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
@@ -449,7 +449,7 @@ drwxrwxr-x          - public_html/users
 drwxrwxr-x          - logs
 drwxrwxr-x          - logs/pbench-satellite-cleanup
 -rw-rw-r--          0 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.error
--rw-rw-r--        962 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
+-rw-rw-r--        928 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
 drwxrwxr-x          - logs/pbench-sync-package-tarballs
 -rw-rw-r--          0 logs/pbench-sync-package-tarballs/pbench-sync-package-tarballs.error
 -rw-rw-r--          0 logs/pbench-sync-package-tarballs/pbench-sync-package-tarballs.log
@@ -535,7 +535,7 @@ run-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01
 run-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: duration (secs): 0
-run-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors
+run-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log
@@ -576,8 +576,8 @@ run-1970-01-01T00:00:42-UTC: Processed 0 tarballs
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.error
 +++++ pbench-satellite-cleanup/pbench-satellite-cleanup.log
 run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup starting
-run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.
-1970-01-01T00:00:42.000000 INFO pbench-satellite-cleanup.report post_status -- @cee:{"@generated-by": {"commit_id": "unit-test", "group_id": 43, "hostname": "example.com", "pid": 42, "user_id": 44, "version": ""}, "@timestamp": "1970-01-01T00:00:42", "chunk_id": 1, "doctype": "status", "name": "pbench-satellite-cleanup", "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.\n\n", "total_chunks": 1, "total_size": 274}
+run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.
+1970-01-01T00:00:42.000000 INFO pbench-satellite-cleanup.report post_status -- @cee:{"@generated-by": {"commit_id": "unit-test", "group_id": 43, "hostname": "example.com", "pid": 42, "user_id": 44, "version": ""}, "@timestamp": "1970-01-01T00:00:42", "chunk_id": 1, "doctype": "status", "name": "pbench-satellite-cleanup", "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.\n\n", "total_chunks": 1, "total_size": 257}
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.log
 +++++ pbench-sync-package-tarballs/pbench-sync-package-tarballs.error
 ----- pbench-sync-package-tarballs/pbench-sync-package-tarballs.error

--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -1,33 +1,3 @@
-+++ Running pbench-server-prep-shim-002
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-01 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-01",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-01-01T00:00:42",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-server-prep-shim-002",
-            "text": "run-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-0_1970.01.01T00.42.00.tar.xz\nrun-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00.tar.xz\nrun-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-w-prefix-dot_1970.01.01T00.42.00.tar.xz\nrun-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-g-normal/tarball-normal_1970.01.01T00.42.00.tar.xz\nrun-1970-01-01T00:00:42-UTC: Processed 7 entries, 4 tarballs successful, 2 quarantined tarballs, 1 duplicately-named tarballs, 0 errors.\n",
-            "total_chunks": 1,
-            "total_size": 941
-        },
-        "_type": "pbench-server-reports"
-    }
-]
---- Finished pbench-server-prep-shim-002 (status=0)
 +++ Running pbench-sync-satellite satellite-one
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -50,14 +20,44 @@ len(actions) = 1
             "chunk_id": 1,
             "doctype": "status",
             "name": "pbench-sync-satellite",
-            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 3 files, with 0 md5 failures and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\npbench-sync-satellite: completing satellite state changes ... (/var/tmp/pbench-test-server/test-5.2/pbench-local/logs/pbench-sync-satellite/ONE/change_state.log)\npbench-sync-satellite: completed satellite state changes\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 3 files processed, with 0 md5 failures and 0 errors\n",
+            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 3 files and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\npbench-sync-satellite: completing satellite state changes ... (/var/tmp/pbench-test-server/test-5.2/pbench-local/logs/pbench-sync-satellite/ONE/change_state.log)\npbench-sync-satellite: completed satellite state changes\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 3 files processed and 0 errors\n",
             "total_chunks": 1,
-            "total_size": 789
+            "total_size": 747
         },
         "_type": "pbench-server-reports"
     }
 ]
 --- Finished pbench-sync-satellite (status=0)
++++ Running pbench-server-prep-shim-002
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:42",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-server-prep-shim-002",
+            "text": "run-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/ONE::controllerA/tarball-simple1_1970-01-01T00:42:00.tar.xz\nrun-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/ONE::controllerB/tarball-simple2_1970-01-01T00:41:00.tar.xz\nrun-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz\nrun-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-0_1970.01.01T00.42.00.tar.xz\nrun-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00.tar.xz\nrun-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-w-prefix-dot_1970.01.01T00.42.00.tar.xz\nrun-1970-01-01T00:00:42-UTC: processed /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-g-normal/tarball-normal_1970.01.01T00.42.00.tar.xz\nrun-1970-01-01T00:00:42-UTC: Processed 10 entries, 7 tarballs successful, 2 quarantined tarballs, 1 duplicately-named tarballs, 0 errors.\n",
+            "total_chunks": 1,
+            "total_size": 1525
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished pbench-server-prep-shim-002 (status=0)
 +++ Running pbench-dispatch
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -452,7 +452,6 @@ drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/INDEXED
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/SATELLITE-DONE
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/SATELLITE-MD5-FAILED
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/SATELLITE-MD5-PASSED
-lrwxrwxrwx        126 archive/fs-version-001/ONE::controllerA/SATELLITE-MD5-PASSED/tarball-simple1_1970-01-01T00:42:00.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerA/tarball-simple1_1970-01-01T00:42:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/SYNCED
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/TO-BACKUP
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/TO-COPY-SOS
@@ -484,7 +483,6 @@ drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/INDEXED
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/SATELLITE-DONE
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/SATELLITE-MD5-FAILED
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/SATELLITE-MD5-PASSED
-lrwxrwxrwx        128 archive/fs-version-001/ONE::controllerB/SATELLITE-MD5-PASSED/tarball-simple2_1970-01-01T00:41:00.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerB/./tarball-simple2_1970-01-01T00:41:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/SYNCED
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/TO-BACKUP
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/TO-COPY-SOS
@@ -506,8 +504,6 @@ drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/WONT-UNPACK
 -rw-rw-r--        220 archive/fs-version-001/ONE::controllerB/tarball-simple2_1970-01-01T00:41:00.tar.xz
 -rw-rw-r--         79 archive/fs-version-001/ONE::controllerB/tarball-simple2_1970-01-01T00:41:00.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC
-drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/.prefix
--rw-rw-r--         16 archive/fs-version-001/ONE::controllerC/.prefix/tarball-simple0-prefix_1970-01-01T00:42:00.prefix
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/BACKED-UP
 lrwxrwxrwx        133 archive/fs-version-001/ONE::controllerC/BACKED-UP/tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/BACKUP-FAILED
@@ -518,7 +514,6 @@ drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/INDEXED
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/SATELLITE-DONE
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/SATELLITE-MD5-FAILED
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/SATELLITE-MD5-PASSED
-lrwxrwxrwx        135 archive/fs-version-001/ONE::controllerC/SATELLITE-MD5-PASSED/tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/./tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/SYNCED
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/TO-BACKUP
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/TO-COPY-SOS
@@ -687,9 +682,7 @@ lrwxrwxrwx        117 public_html/results/ONE::controllerA/tarball-simple1_1970-
 drwxrwxr-x          - public_html/results/ONE::controllerB
 lrwxrwxrwx        117 public_html/results/ONE::controllerB/tarball-simple2_1970-01-01T00:41:00 -> /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerB/tarball-simple2_1970-01-01T00:41:00
 drwxrwxr-x          - public_html/results/ONE::controllerC
-drwxrwxr-x          - public_html/results/ONE::controllerC/prefix0
-drwxrwxr-x          - public_html/results/ONE::controllerC/prefix0/prefix1
-lrwxrwxrwx        124 public_html/results/ONE::controllerC/prefix0/prefix1/tarball-simple0-prefix_1970-01-01T00:42:00 -> /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00
+lrwxrwxrwx        124 public_html/results/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00 -> /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00
 drwxrwxr-x          - public_html/results/controller-b-with-prefixes
 lrwxrwxrwx        121 public_html/results/controller-b-with-prefixes/tarball-0_1970.01.01T00.42.00 -> /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-b-with-prefixes/tarball-0_1970.01.01T00.42.00
 lrwxrwxrwx        132 public_html/results/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00 -> /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00
@@ -766,18 +759,21 @@ drwxrwxr-x          - logs/pbench-re-unpack-tarballs
 -rw-rw-r--        527 logs/pbench-re-unpack-tarballs/pbench-re-unpack-tarballs.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-002
 -rw-rw-r--        650 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
--rw-rw-r--       1015 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
+-rw-rw-r--       1168 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--        219 logs/pbench-sync-satellite/pbench-sync-satellite.error
--rw-rw-r--       1018 logs/pbench-sync-satellite/pbench-sync-satellite.log
+-rw-rw-r--        849 logs/pbench-sync-satellite/pbench-sync-satellite.log
 drwxrwxr-x          - logs/pbench-unpack-tarballs-small
 -rw-rw-r--          0 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
--rw-rw-r--       3317 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
+-rw-rw-r--       3301 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 drwxrwxr-x          - logs/pbench-verify-backup-tarballs
 -rw-rw-r--       3060 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002/ONE::controllerA
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002/ONE::controllerB
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002/ONE::controllerC
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002/controller-b-with-prefixes
 -rw-rw-r--         12 pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/prefix.tarball-w-prefix-dot_1970.01.01T00.42.00
 -rw-rw-r--         12 pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00.prefix
@@ -841,6 +837,7 @@ drwxrwxr-x          - archive/fs-version-001/controllerB/TO-DELETE
 drwxrwxr-x          - archive/fs-version-001/controllerB/TO-SYNC
 drwxrwxr-x          - archive/fs-version-001/controllerC
 drwxrwxr-x          - archive/fs-version-001/controllerC/.prefix
+-rw-rw-r--         16 archive/fs-version-001/controllerC/.prefix/tarball-simple0-prefix_1970-01-01T00:42:00.prefix
 drwxrwxr-x          - archive/fs-version-001/controllerC/SATELLITE-DONE
 lrwxrwxrwx         52 archive/fs-version-001/controllerC/SATELLITE-DONE/tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz -> ../tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controllerC/TO-DELETE
@@ -872,7 +869,7 @@ drwxrwxr-x          - public_html/users
 drwxrwxr-x          - logs
 drwxrwxr-x          - logs/pbench-satellite-cleanup
 -rw-rw-r--          0 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.error
--rw-rw-r--        962 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
+-rw-rw-r--        928 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
 drwxrwxr-x          - logs/pbench-sync-package-tarballs
 -rw-rw-r--          0 logs/pbench-sync-package-tarballs/pbench-sync-package-tarballs.error
 -rw-rw-r--          0 logs/pbench-sync-package-tarballs/pbench-sync-package-tarballs.log
@@ -1094,6 +1091,9 @@ run-1970-01-01T00:00:42-UTC: Quarantined: /var/tmp/pbench-test-server/test-5.2/p
 ----- pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 +++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 run-1970-01-01T00:00:42-UTC
+tarball-simple1_1970-01-01T00:42:00.tar.xz: OK
+./tarball-simple2_1970-01-01T00:41:00.tar.xz: OK
+./tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz: OK
 tarball-0_1970.01.01T00.42.00.tar.xz: OK
 tarball-w-dot-prefix_1970.01.01T00.42.00.tar.xz: OK
 tarball-w-prefix-dot_1970.01.01T00.42.00.tar.xz: OK
@@ -1102,7 +1102,7 @@ md5sum: WARNING: 1 computed checksum did NOT match
 tarball-bad-md5-1_1970.01.01T00.42.00.tar.xz: FAILED
 md5sum: WARNING: 1 computed checksum did NOT match
 tarball-normal_1970.01.01T00.42.00.tar.xz: OK
-run-1970-01-01T00:00:42-UTC: Processed 7 entries, 4 tarballs successful, 2 quarantined tarballs, 1 duplicately-named tarballs, 0 errors.
+run-1970-01-01T00:00:42-UTC: Processed 10 entries, 7 tarballs successful, 2 quarantined tarballs, 1 duplicately-named tarballs, 0 errors.
 1970-01-01T00:00:42.000000 DEBUG pbench-server-prep-shim-002.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-server-prep-shim-002.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
@@ -1114,12 +1114,9 @@ pbench-sync-satellite: completed satellite state changes
 run-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC
-tarball-simple1_1970-01-01T00:42:00.tar.xz.md5
-tarball-simple2_1970-01-01T00:41:00.tar.xz.md5
-tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz.md5
 run-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: duration (secs): 0
-run-1970-01-01T00:00:42-UTC: Total 3 files processed, with 0 md5 failures and 0 errors
+run-1970-01-01T00:00:42-UTC: Total 3 files processed and 0 errors
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log
@@ -1137,7 +1134,7 @@ ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controlle
 run-1970-01-01T00:00:42-UTC: controller-g-normal/tarball-normal_1970.01.01T00.42.00: success - elapsed time (secs): 0 - size (bytes): 216
 ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerA/tarball-simple1_1970-01-01T00:42:00 /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/ONE::controllerA/tarball-simple1_1970-01-01T00:42:00
 run-1970-01-01T00:00:42-UTC: ONE::controllerA/tarball-simple1_1970-01-01T00:42:00: success - elapsed time (secs): 0 - size (bytes): 220
-ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00 /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/ONE::controllerC/prefix0/prefix1/tarball-simple0-prefix_1970-01-01T00:42:00
+ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00 /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00
 run-1970-01-01T00:00:42-UTC: ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00: success - elapsed time (secs): 0 - size (bytes): 228
 ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerB/tarball-simple2_1970-01-01T00:41:00 /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/ONE::controllerB/tarball-simple2_1970-01-01T00:41:00
 run-1970-01-01T00:00:42-UTC: ONE::controllerB/tarball-simple2_1970-01-01T00:41:00: success - elapsed time (secs): 0 - size (bytes): 220
@@ -1174,8 +1171,8 @@ run-1970-01-01T00:00:42-UTC: Processed 7 tarballs
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.error
 +++++ pbench-satellite-cleanup/pbench-satellite-cleanup.log
 run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup starting
-run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 3 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.
-1970-01-01T00:00:42.000000 INFO pbench-satellite-cleanup.report post_status -- @cee:{"@generated-by": {"commit_id": "unit-test", "group_id": 43, "hostname": "example.com", "pid": 42, "user_id": 44, "version": ""}, "@timestamp": "1970-01-01T00:00:42", "chunk_id": 1, "doctype": "status", "name": "pbench-satellite-cleanup", "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 3 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.\n\n", "total_chunks": 1, "total_size": 274}
+run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 3 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.
+1970-01-01T00:00:42.000000 INFO pbench-satellite-cleanup.report post_status -- @cee:{"@generated-by": {"commit_id": "unit-test", "group_id": 43, "hostname": "example.com", "pid": 42, "user_id": 44, "version": ""}, "@timestamp": "1970-01-01T00:00:42", "chunk_id": 1, "doctype": "status", "name": "pbench-satellite-cleanup", "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 3 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.\n\n", "total_chunks": 1, "total_size": 257}
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.log
 +++++ pbench-sync-package-tarballs/pbench-sync-package-tarballs.error
 ----- pbench-sync-package-tarballs/pbench-sync-package-tarballs.error
@@ -1184,10 +1181,13 @@ run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 3 tarballs cle
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ test-execution.log file contents
+ssh pbench-satellite.example.com /var/tmp/pbench-test-server/test-5.2/opt/pbench-server-satellite/bin/pbench-sync-package-tarballs
+ssh pbench-satellite.example.com /var/tmp/pbench-test-server/test-5.2/opt/pbench-server-satellite/bin/pbench-satellite-state-change /var/tmp/pbench-test-server/test-5.2/pbench-satellite/archive/fs-version-001
+restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerA/tarball-simple1_1970-01-01T00:42:00.tar.xz /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerA/tarball-simple1_1970-01-01T00:42:00.tar.xz.md5
+restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerB/tarball-simple2_1970-01-01T00:41:00.tar.xz /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerB/tarball-simple2_1970-01-01T00:41:00.tar.xz.md5
+restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/tarball-simple0-prefix_1970-01-01T00:42:00.tar.xz.md5
 restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-0_1970.01.01T00.42.00.tar.xz /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-0_1970.01.01T00.42.00.tar.xz.md5
 restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00.tar.xz /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00.tar.xz.md5
 restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-prefix-dot_1970.01.01T00.42.00.tar.xz /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-prefix-dot_1970.01.01T00.42.00.tar.xz.md5
 restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-g-normal/tarball-normal_1970.01.01T00.42.00.tar.xz /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-g-normal/tarball-normal_1970.01.01T00.42.00.tar.xz.md5
-ssh pbench-satellite.example.com /var/tmp/pbench-test-server/test-5.2/opt/pbench-server-satellite/bin/pbench-sync-package-tarballs
-ssh pbench-satellite.example.com /var/tmp/pbench-test-server/test-5.2/opt/pbench-server-satellite/bin/pbench-satellite-state-change /var/tmp/pbench-test-server/test-5.2/pbench-satellite/archive/fs-version-001
 --- test-execution.log file contents

--- a/server/bin/gold/test-5.txt
+++ b/server/bin/gold/test-5.txt
@@ -1,3 +1,33 @@
++++ Running pbench-sync-satellite satellite-one
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:42",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-sync-satellite",
+            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors\n",
+            "total_chunks": 1,
+            "total_size": 528
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-server-prep-shim-002
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -28,36 +58,6 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-server-prep-shim-002 (status=0)
-+++ Running pbench-sync-satellite satellite-one
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-01 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-01",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-01-01T00:00:42",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-sync-satellite",
-            "text": "pbench-sync-satellite.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 errors\nRemote ONE: processed 0 files, with 0 md5 failures and 0 errors.\n\nrun-1970-01-01T00:00:42-UTC: start - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC\nrun-1970-01-01T00:00:42-UTC: duration (secs): 0\nrun-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors\n",
-            "total_chunks": 1,
-            "total_size": 570
-        },
-        "_type": "pbench-server-reports"
-    }
-]
---- Finished pbench-sync-satellite (status=0)
 +++ Running pbench-dispatch
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
@@ -403,7 +403,7 @@ drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--          0 logs/pbench-sync-satellite/ONE/change_state.log
 -rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
--rw-rw-r--        870 logs/pbench-sync-satellite/pbench-sync-satellite.log
+-rw-rw-r--        849 logs/pbench-sync-satellite/pbench-sync-satellite.log
 drwxrwxr-x          - logs/pbench-unpack-tarballs-small
 -rw-rw-r--          0 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
 -rw-rw-r--        533 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
@@ -449,7 +449,7 @@ drwxrwxr-x          - public_html/users
 drwxrwxr-x          - logs
 drwxrwxr-x          - logs/pbench-satellite-cleanup
 -rw-rw-r--          0 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.error
--rw-rw-r--        962 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
+-rw-rw-r--        928 logs/pbench-satellite-cleanup/pbench-satellite-cleanup.log
 drwxrwxr-x          - logs/pbench-sync-package-tarballs
 -rw-rw-r--          0 logs/pbench-sync-package-tarballs/pbench-sync-package-tarballs.error
 -rw-rw-r--          0 logs/pbench-sync-package-tarballs/pbench-sync-package-tarballs.log
@@ -535,7 +535,7 @@ run-1970-01-01T00:00:42-UTC: remote tarballs fetched, unpacking ... - 1970-01-01
 run-1970-01-01T00:00:42-UTC: remote tarballs unpacked - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: end - 1970-01-01T00:00:42-UTC
 run-1970-01-01T00:00:42-UTC: duration (secs): 0
-run-1970-01-01T00:00:42-UTC: Total 0 files processed, with 0 md5 failures and 0 errors
+run-1970-01-01T00:00:42-UTC: Total 0 files processed and 0 errors
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-sync-satellite.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log
@@ -576,8 +576,8 @@ run-1970-01-01T00:00:42-UTC: Processed 0 tarballs
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.error
 +++++ pbench-satellite-cleanup/pbench-satellite-cleanup.log
 run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup starting
-run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.
-1970-01-01T00:00:42.000000 INFO pbench-satellite-cleanup.report post_status -- @cee:{"@generated-by": {"commit_id": "unit-test", "group_id": 43, "hostname": "example.com", "pid": 42, "user_id": 44, "version": ""}, "@timestamp": "1970-01-01T00:00:42", "chunk_id": 1, "doctype": "status", "name": "pbench-satellite-cleanup", "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, 0 result removal errors and 0 prefix removal errors.\n\n", "total_chunks": 1, "total_size": 274}
+run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.
+1970-01-01T00:00:42.000000 INFO pbench-satellite-cleanup.report post_status -- @cee:{"@generated-by": {"commit_id": "unit-test", "group_id": 43, "hostname": "example.com", "pid": 42, "user_id": 44, "version": ""}, "@timestamp": "1970-01-01T00:00:42", "chunk_id": 1, "doctype": "status", "name": "pbench-satellite-cleanup", "text": "pbench-satellite-cleanup.run-1970-01-01T00:00:42-UTC(unit-test) - w/ 0 total errors\nTotal 0 tarballs cleaned up, with 0 tarball removal errors, 0 md5 file remove errors, 0 state change errors, 0 incoming removal errors, and 0 result removal errors errors.\n\n", "total_chunks": 1, "total_size": 257}
 ----- pbench-satellite-cleanup/pbench-satellite-cleanup.log
 +++++ pbench-sync-package-tarballs/pbench-sync-package-tarballs.error
 ----- pbench-sync-package-tarballs/pbench-sync-package-tarballs.error

--- a/server/bin/pbench-dispatch.sh
+++ b/server/bin/pbench-dispatch.sh
@@ -129,7 +129,7 @@ while read tarball ;do
     # producing the error
     if [ ${resultname%%.*} == "DUPLICATE__NAME" ] ;then
         let ndups+=1
-        quarantine ${controller_path}/_QUARANTINED/DUPLICATES ${link} ${link}.md5 ${controller_path}/.prefix/${resultname}.prefix
+        quarantine ${controller_path}/_QUARANTINED/DUPLICATES ${link} ${link}.md5
         rm -f ${tarball}
         status=$?
         if [ $status -ne 0 ] ;then
@@ -153,7 +153,7 @@ while read tarball ;do
     popd >/dev/null 2>&4
     if [ $sts -ne 0 ] ;then
         log_error "$TS: MD5 check of ${link} failed for ${tarball}" "${mail_content}"
-        quarantine ${controller_path}/_QUARANTINED/BAD-MD5 ${link} ${link}.md5 ${controller_path}/.prefix/${resultname}.prefix
+        quarantine ${controller_path}/_QUARANTINED/BAD-MD5 ${link} ${link}.md5
         rm -f ${tarball}
         status=$?
         if [ $status -ne 0 ] ;then

--- a/server/bin/pbench-satellite-cleanup.sh
+++ b/server/bin/pbench-satellite-cleanup.sh
@@ -25,7 +25,6 @@ typeset -i nmd5errs=0
 typeset -i nstateerrs=0
 typeset -i nincomingerrs=0
 typeset -i nresultserrs=0
-typeset -i nprefixerrs=0
 
 mail_content=$tmp/mail.log
 index_content=$tmp/index_mail_contents
@@ -100,17 +99,7 @@ for host in $hosts; do
             fi
         fi
         # remove the results
-        prefix=".prefix/${x%%.tar.xz}.prefix"
-        if [ -e $prefix ]; then
-            prefix_value=$(cat ".prefix/${x%%.tar.xz}.prefix")
-        else
-            prefix_value=""
-        fi
-        if [ -z "$prefix_value" ]; then
-            sym_link=$RESULTS/$host/${x%%.tar.xz}
-        else
-            sym_link=$RESULTS/$host/$prefix_value/${x%%.tar.xz}
-        fi
+        sym_link=$RESULTS/$host/${x%%.tar.xz}
         if [ -L $sym_link ]; then
             rm $sym_link
             rc=$?
@@ -119,28 +108,19 @@ for host in $hosts; do
                 nresultserrs=$nresultserrs+1
             fi
         fi
-        # remove prefix if present
-        if [ -e $prefix ]; then
-            rm $prefix
-            rc=$?
-            if [ $rc != 0 ]; then
-                log_error "$TS: Failed to remove prefix file: $prefix, code: $rc" "${mail_content}"
-                nprefixerrs=$nprefixerrs+1
-            fi
-        fi
     done
     popd > /dev/null 2>&4
 done
 
 summary="Total $ntb tarballs cleaned up, with $ntberrs tarball removal errors, $nmd5errs md5 file \
-remove errors, $nstateerrs state change errors, $nincomingerrs incoming removal errors, $nresultserrs \
-result removal errors and $nprefixerrs prefix removal errors."
+remove errors, $nstateerrs state change errors, $nincomingerrs incoming removal errors, and $nresultserrs \
+result removal errors errors."
 
 log_info "$TS: $PROG ends: $summary"
 
 log_finish
 
-nerrs=$ntberrs+$nmd5errs+$nstateerrs+$nincomingerrs+$nresultserrs+$nprefixerrs
+nerrs=$ntberrs+$nmd5errs+$nstateerrs+$nincomingerrs+$nresultserrs
 
 subj="$PROG.$TS($PBENCH_ENV) - w/ $nerrs total errors"
 cat << EOF > $index_content

--- a/server/bin/pbench-sync-package-tarballs.sh
+++ b/server/bin/pbench-sync-package-tarballs.sh
@@ -17,17 +17,6 @@ tmp=$(get-tempdir-name $PROG)
 trap "rm -rf $tmp" EXIT
 mkdir -p "$tmp" || exit 1
 
-calculate_prefixname () {
-    local prefix
-
-    tarname=${1##*/}
-    prefixname=${tarname%%.tar.xz}
-    despath=${1%/*}
-    prefixpath=".prefix/$prefixname.prefix"
-    prefix="$despath/$prefixpath"
-    echo $prefix
-}
-
 calculate_md5_prefix () {
     local tar_list
 
@@ -39,10 +28,6 @@ calculate_md5_prefix () {
                 echo "$tar.md5"
             else
                 echo Failed: "$remotearchive/$tar" exist but "$remotearchive/$tar.md5" not exist >&4
-            fi
-            prefix=$(calculate_prefixname $tar)
-            if [ -s $remotearchive/$prefix ]; then
-                echo "$prefix"
             fi
         else
             echo Failed: "$remotearchive/$tar" not exist >&4

--- a/server/bin/pbench-unpack-tarballs.sh
+++ b/server/bin/pbench-unpack-tarballs.sh
@@ -287,14 +287,6 @@ function do_work() {
         prefix=$(getconf.py -C ${INCOMING}/${hostname}/${resultname}/metadata.log prefix run)
         user=$(getconf.py -C ${INCOMING}/${hostname}/${resultname}/metadata.log user run)
 
-        # Version 001 agents use a prefix file.  If there is a prefix file,
-        # create a link as specified in the prefix file.  pbench-dispatch
-        # has already moved it to the .prefix subdir
-        prefixfile=${basedir}/.prefix/${resultname}.prefix
-        if [[ -f ${prefixfile} ]]; then
-            prefix=$(cat ${prefixfile})
-        fi
-
         # if non-empty and does not contain a trailing slash, add one
         if [[ ! -z "${prefix}" && "${prefix%/}" = "${prefix}" ]]; then
             prefix=${prefix}/

--- a/server/bin/state/test-11.setup
+++ b/server/bin/state/test-11.setup
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd $_testopt/unittest-scripts || exit $?
+ln -s failing-mv mv || exit $?
+echo pbench-user-benchmark_38_2016-05-18 > mv.FAIL_ON
+exit $?

--- a/server/bin/test-bin/failing-mv
+++ b/server/bin/test-bin/failing-mv
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Fail a mv command if first argument's basename starts with ${_FAIL_MV_ON}.
+_FAIL_MV_ON=$(<${0}.FAIL_ON)
+if [[ ! -z "${_FAIL_MV_ON}" && $(basename ${1}) == ${_FAIL_MV_ON}* ]]; then
+    echo "mv: failed on ${*}" >&2
+    exit 1
+fi
+/bin/mv "${@}"

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -93,13 +93,14 @@ function _run_activate {
 }
 
 function _run_allscripts {
-    # These three pull in new tar balls from move-results and remote
-    # satellite pbench servers feeding them into the dispatch loop.
-    _run pbench-server-prep-shim-002
+    # Pull in new tar balls the remote satellite pbench servers and feed them
+    # into the dispatch loop.
     # NOTE WELL: the "satellite-one" argument refers a configuration
     # section in the unit test's pbench-server.cfg file - keep them
     # synchronized.
     _run pbench-sync-satellite satellite-one
+    # Pull new tar balls from move-results and feed them into the dispatch loop.
+    _run pbench-server-prep-shim-002
     # These next five are related and would flow in this order.
     _run pbench-dispatch
     _run pbench-unpack-tarballs small


### PR DESCRIPTION
This turned out to be a bit more subtle, but in the end not too bad.

Basically, we just want `pbench-sync-satellite` to create the same final state that `pbench-copy-result-tb` creates, which is just placing a .md5 and .tar.xz in a controller directory in the receive tree.  But we need to maintain the remote updates for the satellite.

However, we have some legacy vestiges of the very old `.prefix` files. Rather than try to carry over that supporting behavior from sync- satellite, I just removed it entirely from the rest of the code base.

The unit tests proved very useful to see the behaviors that were taking place, and they have been updated accordingly. Note that the .prefix files are ignored and show up in the test output either as unexpected files and directories and as tar balls that no longer have a prefix.